### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Mcp tools powered by aimcp, find mcps whatever you want. This server allows searching the MCP Hub for available MCPs.
 
+<a href="https://glama.ai/mcp/servers/@hekmon8/mcp-hub-tools">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hekmon8/mcp-hub-tools/badge" alt="Hub Tools MCP server" />
+</a>
+
 ## Open Protocol
 
 This server implements the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol/specification). It acts as an MCP server that can be connected to by MCP clients (like compatible AI assistants or development tools).


### PR DESCRIPTION
This PR adds a badge for the [MCP Hub Tools](https://glama.ai/mcp/servers/@hekmon8/mcp-hub-tools) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@hekmon8/mcp-hub-tools">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@hekmon8/mcp-hub-tools/badge" alt="Hub Tools MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.